### PR TITLE
Add another noise message from Devel::Cover

### DIFF
--- a/lib/TAP/Formatter/Session/TeamCity.pm
+++ b/lib/TAP/Formatter/Session/TeamCity.pm
@@ -255,7 +255,8 @@ sub _handle_unknown {
 
     # This is noise from Devel::Cover that we don't want to throw out
     # entirely, but also should not affect the test status either.
-    elsif ( $raw =~ qr/Deep recursion on subroutine "B::Deparse/ ) {
+    elsif ($raw =~ qr/Deep recursion on subroutine "B::Deparse/
+        || $raw =~ qr{unexpected OP_.+?B/Deparse} ) {
         $self->_tc_message(
             'message',
             { text => $raw },


### PR DESCRIPTION
These can come from new ops, e.g. from Ref::Util, that make B::Deparse emit a warning
